### PR TITLE
ZeroFOX - Updated App Display Name

### DIFF
--- a/ZeroFox/ZeroFOX Cloud.json
+++ b/ZeroFox/ZeroFOX Cloud.json
@@ -1,7 +1,7 @@
 {
     "type": "FolderSyncDefinition",
-    "name": "ZeroFOX Dash/Queries",
-    "description": "This folder contains all of the queries and the dashboard for ZeroFOX Cloud.",
+    "name": "ZeroFOX",
+    "description": "This folder contains all of the queries and the dashboard for the ZeroFOX platform.",
     "children": [
         {
             "type": "SavedSearchWithScheduleSyncDefinition",


### PR DESCRIPTION
Changed the Apps display name to "ZeroFOX" for clarity.

# PR Details

This PR updates the ZeroFOX app display name in the App Catalog (removes "Dash/Queries" from the name).

## Description

Change to appName in the app manifest.

## Related Issue

N/A


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Changes follows the best practices from the given [docs](https://docs.google.com/document/d/1xfYfruru0RFWOH23GRrRzosSlepJUTcakLFHLHdpEtc/edit?usp=sharing).
- [x] Updated CHANGELOG.md.
- [x] Ran unit tests locally.
- [x] Updated screenshots/sample logs if any.
